### PR TITLE
Issue 11: Add map loading message

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 </head>
 
 <body>
+  <div id="loading">Loading...</div>
   <div id="map">
     <div id="right" class="sidebar flex-center right collapsed">
       <div class="sidebar-content rounded-rect flex-center">
@@ -152,7 +153,7 @@
       { imageUrl: 'https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/RooftopHub.png', id: 'RH_icon' },
       { imageUrl: 'https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/icon1.png', id: 'MN_icon' },
       { imageUrl: 'https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/Rooftophubs2.png', id: 'LB_icon' },
-    ]
+    ];
 
     Promise.all(
       images.map(img => new Promise((resolve, reject) => {
@@ -215,7 +216,15 @@
       ]
 
       // wait for all promises to resolve before adding data to Sources
-      const [networkpoints_data, level1_data, level2_data, level3_data] = await Promise.all(fetch_promises)
+      const [networkpoints_data, level1_data, level2_data, level3_data] = await Promise.all(fetch_promises);
+
+      // hide loading message now that all data has been fetched
+      const loadingMessage = document.querySelector('#loading');
+      if (loadingMessage) {
+        // This if statement should always be true, but this avoids crashing the site if somehow the element
+        // has been removed.
+        loadingMessage.style.display = 'none';
+      }
 
       map.addSource('network-points', {
         type: 'geojson',

--- a/style.css
+++ b/style.css
@@ -1,4 +1,14 @@
-body { margin: 0; padding: 0; }
+html { height: 100%; }
+
+body {
+  margin: 0;
+  padding: 0;
+
+  /* Needed to easily vertically center the loading message */
+  display: flex;
+  height: 100%;
+}
+
 #map { position: absolute; top: 0; bottom: 0; width: 100%; }
 
 .layer-icon {
@@ -101,5 +111,15 @@ body { margin: 0; padding: 0; }
 
 .bookmarks div[style*="font-weight: bold"] {
   margin-top: 10px; /* Adjust this value to increase/decrease the space */
+}
+
+#loading {
+  /* Chosen to contrast with the sidebar colors, since it's rendered above the sidebar on small enough viewports. */
+  background: white;
+
+  border-radius: 4px;
+  padding: 1rem;
+  margin: auto;
+  z-index: 999; /** Needs to be larger than the map, sidebar, and other future elements. */
 }
 


### PR DESCRIPTION
Adds a loading message while the site is fetching the map data.

Here's a video recording of it on a larger viewport:
https://github.com/user-attachments/assets/9bdb5d1f-cc87-4744-9dc3-4724395ff6f6

And here's one on a smaller viewport:
https://github.com/user-attachments/assets/7cfbf5a1-15bc-4e7d-acec-3df22c9f4d1d

Lemme know if you'd prefer a loading spinner instead of the text!

