### PR TITLE
refactor network layer data loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,6 @@
     });
 
     // Add the GeoJSON layers to the map
-    let layer_one_loaded = false;
     map.on('load', async () => {
       // setup util functions
       const loadNetworkLayer = async (endpoint, name) => {

--- a/index.html
+++ b/index.html
@@ -88,17 +88,17 @@
           </div>
           <div style="font-weight: bold">Animate Network:</div>
           <label class="switch-container">
-            <input type="checkbox" id="toggleNetworkLinks" />
+            <input type="checkbox" id="toggleNetworkLinks" disabled />
             <div class="switch"></div>
             <div>Level 1</div>
           </label>
           <label class="switch-container">
-            <input type="checkbox" id="toggleNetworkLinks2" />
+            <input type="checkbox" id="toggleNetworkLinks2" disabled />
             <div class="switch"></div>
             <div>Level 2</div>
           </label>
           <label class="switch-container">
-            <input type="checkbox" id="toggleNetworkLinks3" />
+            <input type="checkbox" id="toggleNetworkLinks3" disabled />
             <div class="switch"></div>
             <div>Level 3</div>
           </label>
@@ -113,6 +113,8 @@
 
   <script src="https://api.mapbox.com/mapbox-gl-js/v2.13.0/mapbox-gl.js"></script>
   <script>
+    const fetchJSON = (url) => fetch(url).then(r => r.json());
+
     mapboxgl.accessToken = 'pk.eyJ1IjoiZm12YWxkZXpnODQiLCJhIjoiY2xqajJzZXZ2MDU3ZTNybHBrdHo4OWo4aSJ9.ENnejUYGtJT-74gG0opSQA';
 
     // Default values for map center and zoom
@@ -168,110 +170,65 @@
     });
 
     // Add the GeoJSON layers to the map
-
+    let layer_one_loaded = false;
     map.on('load', async () => {
-      // fetch datasources
-      // networkpoints 
-      // const networkpoints_url = 'https://script.google.com/macros/s/AKfycbwfmdSpYrkW_z3DFMO87yPzaplL5T6t8CuEeFXRKA6JRn4OGSzvFo-ynRPAGQ_aBMlu_Q/exec?get_geojson'
-      // layer1 
-      // const level1_url = 'https://script.google.com/macros/s/AKfycbwfmdSpYrkW_z3DFMO87yPzaplL5T6t8CuEeFXRKA6JRn4OGSzvFo-ynRPAGQ_aBMlu_Q/exec?get_level1'
-      // layer2 
-      // const level2_url = 'https://script.google.com/macros/s/AKfycbwfmdSpYrkW_z3DFMO87yPzaplL5T6t8CuEeFXRKA6JRn4OGSzvFo-ynRPAGQ_aBMlu_Q/exec?get_level2'
-      // layer3 
-      // const level3_url = 'https://script.google.com/macros/s/AKfycbwfmdSpYrkW_z3DFMO87yPzaplL5T6t8CuEeFXRKA6JRn4OGSzvFo-ynRPAGQ_aBMlu_Q/exec?get_level3'
-
-      // new and faster!
-      const networkpoints_url = "https://pcwnetworkmap-internal-api-170f675937bb.herokuapp.com/get_networkpoints"
-      const level1_url = "https://pcwnetworkmap-internal-api-170f675937bb.herokuapp.com/get_level1"
-      const level2_url = "https://pcwnetworkmap-internal-api-170f675937bb.herokuapp.com/get_level2"
-      const level3_url = "https://pcwnetworkmap-internal-api-170f675937bb.herokuapp.com/get_level3"
-
-      // define promises for data to fetch
-      fetch_promises = [
-        fetch(networkpoints_url).then(
-          response => response.json()
-        ).then(
-          data => {
-            return data
+      // setup util functions
+      const loadNetworkLayer = async (endpoint, name) => {
+        const api_endpoint = "https://pcwnetworkmap-internal-api-170f675937bb.herokuapp.com";
+        let layer_data;
+        try {
+          layer_data = await fetchJSON(api_endpoint + endpoint);
+          map.addSource(name, {
+            type: 'geojson',
+            data: layer_data
+          });
+        }
+        catch (e) {
+          'error loading network connection layer', name, e
+        }
+        return layer_data;
+      }
+      const initAnimateNetworkLine = (id) => {
+        // technique based on https://jsfiddle.net/2mws8y3q/
+        const dashSequence = [
+          [0, 4, 3],
+          [0.5, 4, 2.5],
+          [1, 4, 2],
+          [1.5, 4, 1.5],
+          [2, 4, 1],
+          [2.5, 4, 0.5],
+          [3, 4, 0],
+          [0, 0.5, 3, 3.5],
+          [0, 1, 3, 3],
+          [0, 1.5, 3, 2.5],
+          [0, 2, 3, 2],
+          [0, 2.5, 3, 1.5],
+          [0, 3, 3, 1],
+          [0, 3.5, 3, 0.5]
+        ];
+        let step = 0;
+        const animateNetworkLine = (timestamp = 0) => {
+          // Update line-dasharray using the next value in dashArraySequence. The
+          // divisor in the expression `timestamp / 100` controls the animation speed.
+          const nextStep = parseInt((timestamp / 100) % dashSequence.length);
+          if (nextStep !== step) {
+            map.setPaintProperty(id, 'line-dasharray', dashSequence[step]);
+            step = nextStep;
           }
-        ),
+          requestAnimationFrame(animateNetworkLine);
+        }
+        animateNetworkLine();
+      }
+      // end util
 
-        fetch(level1_url).then(
-          response => response.json()
-        ).then(
-          data => {
-            return data
-          }
-        ),
-
-        fetch(level2_url).then(
-          response => response.json()
-        ).then(
-          data => {
-            return data
-          }
-        ),
-
-        fetch(level3_url).then(
-          response => response.json()
-        ).then(
-          data => {
-            return data
-          }
-        )
-      ]
-
-      // wait for all promises to resolve before adding data to Sources
-      const [networkpoints_data, level1_data, level2_data, level3_data] = await Promise.all(fetch_promises);
-
-      // hide loading message now that all data has been fetched
-      const loadingMessage = document.querySelector('#loading');
-      if (loadingMessage) {
-        // This if statement should always be true, but this avoids crashing the site if somehow the element
-        // has been removed.
-        loadingMessage.style.display = 'none';
+      // load the basic nodes for display
+      const networkpoints_data = await loadNetworkLayer('/get_networkpoints', 'network-points');
+      
+      if (!networkpoints_data) {
+        alert("Error loading network points");
+        throw ReferenceError("Didn't load required network points");
       }
 
-      map.addSource('network-points', {
-        type: 'geojson',
-        // data: 'https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/data/networkpoints.geojson'
-        data: networkpoints_data
-      });
-
-      map.addSource('line', {
-        type: 'geojson',
-        // data: 'https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/data/level1.geojson'
-        data: level1_data
-      });
-
-      map.addSource('new-line', {
-        type: 'geojson',
-        // data: 'https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/data/level2.geojson'
-        data: level2_data
-      });
-
-      map.addSource('new-line2', {
-        type: 'geojson',
-        // data: 'https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/data/level3.geojson'
-        data: level3_data
-      });
-
-
-      // add a line layer without line-dasharray defined to fill the gaps in the dashed line
-      //map.addLayer({
-      //type: 'line',
-      //source: 'line',
-      //id: 'line-background',
-      //visibility: 'none',
-      //minzoom: 13,
-      //paint: {
-      //'line-color': 'lime',
-      //'line-width': 4,
-      //'line-opacity': 0.4
-      //}
-      //});
-
-      // Add Network Points Layer
       map.addLayer({
         'id': 'network-points-layer',
         'type': 'symbol',
@@ -298,79 +255,85 @@
         },
       });
 
-      // Level 1
-      // add a line layer with line-dasharray set to the first value in dashArraySequence
-      map.addLayer({
-        type: 'line',
-        source: 'line',
-        id: 'line-dashed',
-        visibility: 'none',
-        minzoom: 13,
-        paint: {
-          'line-color': 'lime',
-          'line-width': 2,
-          'line-dasharray': [0, 4, 3],
-          'line-opacity': 0.65,
-        }
-      });
+      const loadingMessage = document.querySelector('#loading');
+      if (loadingMessage) {
+        loadingMessage.style.display = 'none';
+      }
 
-      //map.addLayer({
-      //type: 'line',
-      //source: 'new-line',
-      //id: 'new-line-background',
-      //visibility: 'none',
-      //minzoom: 13,
-      //paint: {
-      //'line-color': 'magenta',
-      //'line-width': 4,
-      //'line-opacity': 0.4
-      //}
-      //});
+      // Level 1
+      loadNetworkLayer('/get_level1', 'line').then(() => {
+        const animationLineId = 'line-dashed';
+        map.addLayer({
+          type: 'line',
+          source: 'line',
+          id: animationLineId,
+          visibility: 'none',
+          minzoom: 13,
+          paint: {
+            'line-color': 'lime',
+            'line-width': 2,
+            'line-opacity': 0.65,
+          }
+        });
+        initAnimateNetworkLine(animationLineId);
+        map.setLayoutProperty(animationLineId, 'visibility', 'none');
+
+        const checkbox = document.getElementById("toggleNetworkLinks");
+        checkbox.disabled = false;
+      })
 
       // Level 2
-      // Add a line layer with line-dasharray set to the first value in dashArraySequence for the new layer
-      map.addLayer({
-        type: 'line',
-        source: 'new-line',
-        id: 'new-line-dashed',
-        visibility: 'none',
-        minzoom: 13,
-        paint: {
-          'line-color': 'magenta',
-          'line-width': 4,
-          'line-opacity': 0.65,
-        }
+      loadNetworkLayer('/get_level2', 'new-line').then(() => {
+        const animationLineId = 'new-line-dashed';
+        map.addLayer({
+          type: 'line',
+          source: 'new-line',
+          id: animationLineId,
+          visibility: 'none',
+          minzoom: 13,
+          paint: {
+            'line-color': 'magenta',
+            'line-width': 4,
+            'line-opacity': 0.65,
+          }
+        });
+        initAnimateNetworkLine(animationLineId);
+        map.setLayoutProperty(animationLineId, 'visibility', 'none');
+
+        const checkbox = document.getElementById("toggleNetworkLinks2");
+        checkbox.disabled = false;
       });
 
       // Level 3
-      map.addLayer({
-        type: 'line',
-        source: 'new-line2',
-        id: 'new-line-dashed2',
-        visibility: 'none',
-        minzoom: 13,
-        paint: {
-          'line-color': 'yellow',
-          'line-width': 3,
-          'line-dasharray': [0, 4, 3],
-          'line-opacity': 0.65,
-        }
+      loadNetworkLayer('/get_level3', 'new-line2').then(() => {
+        const animationLineId = 'new-line-dashed2';
+        map.addLayer({
+          type: 'line',
+          source: 'new-line2',
+          id: animationLineId,
+          visibility: 'none',
+          minzoom: 13,
+          paint: {
+            'line-color': 'yellow',
+            'line-width': 4,
+            'line-opacity': 0.65,
+          }
+        });
+        initAnimateNetworkLine(animationLineId);
+        map.setLayoutProperty('new-line-dashed2', 'visibility', 'none');
+        
+        const checkbox = document.getElementById("toggleNetworkLinks3");
+        checkbox.disabled = false;
       });
 
-      // Don't add heatmap source/layer until data is loaded and source created
-
-      // Filter features by the "type" property
+      // Create heatmap based on features' "type" property
       const filteredData = networkpoints_data.features.filter(feature => feature.properties.type === 'RH' || feature.properties.type === 'MN' || feature.properties.type === 'LB');
-
-      // Create a new GeoJSON object with the filtered features
-      const filteredGeoJSON = {
-        type: 'FeatureCollection',
-        features: filteredData
-      };
-
       map.addSource('heatmap-source', {
         type: 'geojson',
-        data: filteredGeoJSON // Use the filtered GeoJSON data
+        data: {
+          type: 'FeatureCollection',
+          features: filteredData
+        }
       });
 
       const heatmapLayer = {
@@ -380,22 +343,18 @@
         minzoom: 12,
         maxzoom: 20,
         paint: {
-
           'heatmap-weight': 5,
-          // Heatmap intensity range
           'heatmap-intensity': 1,
-          // Heatmap color gradient
           'heatmap-color': [
             'interpolate',
             ['linear'],
             ['heatmap-density'],
-            0, 'rgba(0, 0, 255, 0)', // adjust the color gradient as needed
+            0, 'rgba(0, 0, 255, 0)',
             0.2, 'rgba(255, 0, 0, 1)',
             0.4, 'rgba(255, 165, 0, 1)',
             0.6, 'rgba(255, 255, 0, 1)',
             0.8, 'rgba(0, 255, 0, 1)'
           ],
-          // Heatmap radius
           'heatmap-radius': {
             stops: [
               [9, 2],
@@ -407,7 +366,6 @@
               [23, 1000]
             ]
           },
-          // Heatmap opacity
           'heatmap-opacity': {
             default: 1,
             stops: [
@@ -420,20 +378,7 @@
       };
 
       map.addLayer(heatmapLayer);
-
-      // Start the animations
-      animateDashArray(0);
-      animateNewLine(0);
-      animateNewLine2(0);
-
       map.setLayoutProperty(heatmapLayer.id, 'visibility', 'none');
-      map.setLayoutProperty('line-background', 'visibility', 'none');
-      map.setLayoutProperty('line-dashed', 'visibility', 'none');
-      map.setLayoutProperty('new-line-background', 'visibility', 'none');
-      map.setLayoutProperty('new-line-dashed', 'visibility', 'none');
-      map.setLayoutProperty('new-line-background', 'visibility', 'none');
-      map.setLayoutProperty('new-line-dashed2', 'visibility', 'none');
-
 
       map.on('mouseenter', 'network-points-layer', (e) => {
         map.getCanvas().style.cursor = 'pointer';
@@ -453,170 +398,38 @@
         popup.remove();
       });
 
-    }); //end map.on('load')
+    });
+    //end map.on('load')
 
-
-    // technique based on https://jsfiddle.net/2mws8y3q/
-    // an array of valid line-dasharray values, specifying the lengths of the alternating dashes and gaps that form the dash pattern
-    const dashArraySequence = [
-      [0, 4, 3],
-      [0.5, 4, 2.5],
-      [1, 4, 2],
-      [1.5, 4, 1.5],
-      [2, 4, 1],
-      [2.5, 4, 0.5],
-      [3, 4, 0],
-      [0, 0.5, 3, 3.5],
-      [0, 1, 3, 3],
-      [0, 1.5, 3, 2.5],
-      [0, 2, 3, 2],
-      [0, 2.5, 3, 1.5],
-      [0, 3, 3, 1],
-      [0, 3.5, 3, 0.5]
-    ];
-
-    let step = 0;
-
-    function animateDashArray(timestamp) {
-      // Update line-dasharray using the next value in dashArraySequence. The
-      // divisor in the expression `timestamp / 100` controls the animation speed.
-      const newStep = parseInt((timestamp / 100) % dashArraySequence.length);
-
-      if (newStep !== step) {
-        map.setPaintProperty('line-dashed', 'line-dasharray', dashArraySequence[step]);
-        step = newStep;
-      }
-
-      // Request the next frame of the animation.
-      requestAnimationFrame(animateDashArray);
-    }
-
-    const dashArraySequence2 = [
-      [0, 4, 3],
-    ];
-
-    let step2 = 0;
-
-    function animateNewLine(timestamp) {
-      //Update line-dasharray using the next value in dashArraySequence for the new layer.
-      const newStep2 = parseInt((timestamp / 200) % dashArraySequence2.length);
-
-      if (newStep2 !== step2) {
-        map.setPaintProperty('new-line-dashed', 'line-dasharray', dashArraySequence2[step2]);
-        step2 = newStep2;
-      }
-
-      // Request the next frame of the animation.
-      requestAnimationFrame(animateNewLine);
-    }
-
-    const dashArraySequence3 = [
-      [0, 4, 3],
-      [0.5, 4, 2.5],
-      [1, 4, 2],
-      [1.5, 4, 1.5],
-      [2, 4, 1],
-      [2.5, 4, 0.5],
-      [3, 4, 0],
-      [0, 0.5, 3, 3.5],
-      [0, 1, 3, 3],
-      [0, 1.5, 3, 2.5],
-      [0, 2, 3, 2],
-      [0, 2.5, 3, 1.5],
-      [0, 3, 3, 1],
-      [0, 3.5, 3, 0.5]
-    ];
-
-    let step3 = 0;
-
-    function animateNewLine2(timestamp) {
-      // Update line-dasharray using the next value in dashArraySequence for the new layer.
-      const newStep3 = parseInt((timestamp / 200) % dashArraySequence3.length);
-
-      if (newStep3 !== step3) {
-        map.setPaintProperty('new-line-dashed2', 'line-dasharray', dashArraySequence3[step3]);
-        step3 = newStep3;
-      }
-
-      // Request the next frame of the animation.
-      requestAnimationFrame(animateNewLine2);
-    }
-
-    // Add event listener to the checkbox input
     const toggleCheckbox = document.getElementById('toggleNetworkLinks');
     toggleCheckbox.addEventListener('change', () => {
-      toggleAnimateNetworkLinks();
+      map.setLayoutProperty(
+        'line-dashed',
+        'visibility',
+        toggleCheckbox.checked ? 'visible' : 'none'
+      );
     });
 
-    function toggleAnimateNetworkLinks() {
-      const lineBackgroundLayer = map.getLayer('line-background');
-      const lineDashedLayer = map.getLayer('line-dashed');
-
-      // If the checkbox is checked, make both layers visible
-      if (toggleCheckbox.checked) {
-        map.setLayoutProperty('line-background', 'visibility', 'visible');
-        map.setLayoutProperty('line-dashed', 'visibility', 'visible');
-      } else {
-        // Otherwise, make both layers invisible
-        map.setLayoutProperty('line-background', 'visibility', 'none');
-        map.setLayoutProperty('line-dashed', 'visibility', 'none');
-      }
-    }
-
-    // Add event listener to the checkbox input for the new layer
     const newLayerCheckbox = document.getElementById('toggleNetworkLinks2');
     newLayerCheckbox.addEventListener('change', () => {
-      toggleNewLine();
+      map.setLayoutProperty(
+        'new-line-dashed',
+        'visibility',
+        newLayerCheckbox.checked ? 'visible' : 'none'
+      );
     });
 
-    // Add event listener to the checkbox input for level 3 layer
     const newLayerCheckbox2 = document.getElementById('toggleNetworkLinks3');
     newLayerCheckbox2.addEventListener('change', () => {
-      toggleNewLine2();
+      map.setLayoutProperty(
+        'new-line-dashed2',
+        'visibility',
+        newLayerCheckbox2.checked ? 'visible' : 'none'
+      );
     });
-
-
-    function toggleNewLine() {
-      const newLineBackgroundLayer = map.getLayer('new-line-background');
-      const newLineDashedLayer = map.getLayer('new-line-dashed');
-
-      // If the checkbox is checked, make both layers visible and start the animation
-      if (newLayerCheckbox.checked) {
-        map.setLayoutProperty('new-line-background', 'visibility', 'visible');
-        map.setLayoutProperty('new-line-dashed', 'visibility', 'visible');
-        step2 = 0;
-        animateNewLine(0); // Start the animation
-      } else {
-        // Otherwise, make both layers invisible
-        map.setLayoutProperty('new-line-background', 'visibility', 'none');
-        map.setLayoutProperty('new-line-dashed', 'visibility', 'none');
-        cancelAnimationFrame(animateNewLine);
-      }
-    }
-
-    function toggleNewLine2() {
-      const newLineBackgroundLayer2 = map.getLayer('new-line-background2');
-      const newLineDashedLayer2 = map.getLayer('new-line-dashed2');
-
-      // If the checkbox is checked, make both layers visible and start the animation
-      if (newLayerCheckbox2.checked) {
-        map.setLayoutProperty('new-line-background2', 'visibility', 'visible');
-        map.setLayoutProperty('new-line-dashed2', 'visibility', 'visible');
-        step2 = 0;
-        animateNewLine2(0); // Start the animation
-      } else {
-        // Otherwise, make both layers invisible
-        map.setLayoutProperty('new-line-background2', 'visibility', 'none');
-        map.setLayoutProperty('new-line-dashed2', 'visibility', 'none');
-        cancelAnimationFrame(animateNewLine2);
-      }
-    }
-
 
     const popup = new mapboxgl.Popup({ closeButton: false, closeOnClick: false });
 
-
-    // Function to navigate to a bookmark
     function navigateToBookmark(bookmarkId, pitch, bearing) {
       switch (bookmarkId) {
         case 1:


### PR DESCRIPTION
This touches a significant portion of the code. I've thoroughly tested it to insure it's functional alike before.

Notes:
- deleted significant deprecated code and useless comments
- created two helper functions to clean up significant amount of duplicate code
  - `loadNetworkLayer`,`initAnimateNetworkLine`
- separated loading of network points and layer data into separate Promises instead of binding them all together using `Promise.all`
  - While it's unlikely only one would fail, since they're all the same API, this is less brittle imo and handles better overall
- bound network connection layer checkboxes' disabled state to layer data being loaded
- normalized animation of network lines