### PR TITLE
move html out of map div

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,156 +17,155 @@
 
 <body>
   <div id="loading">Loading...</div>
-  <div id="map">
-    <div id="right-sidebar" class="sidebar flex-center right collapsed">
-      <div class="sidebar-content rounded-rect flex-center">
-        <div class="bookmarks">
-          <div style="font-weight: bold">Select layers</div>
-          <div class='relative bg-gray-lighter mx6 my6 w180 round flex flex--column'>
-            <label class='checkbox-container'>
-              <input type='checkbox' id="layer1" checked />
-              <div class='checkbox mr6 checkbox--s-label'>
-                <svg class='icon'>
-                  <use xlink:href='#icon-check' />
-                </svg>
-              </div>
-              <img class="layer-icon"
-                src="https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/high_sites.png">
-              High Sites
-            </label>
-            <label class='checkbox-container'>
-              <input type='checkbox' id="layer4" checked />
-              <div class='checkbox mr6 checkbox--s-label'>
-                <svg class='icon'>
-                  <use xlink:href='#icon-check' />
-                </svg>
-              </div>
-              <img class="layer-icon"
-                src="https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/Rooftophubs2.png">
-              Main Router
-            </label>
-            <label class='checkbox-container'>
-              <input type='checkbox' id="layer2" checked />
-              <div class='checkbox mr6 checkbox--s-label'>
-                <svg class='icon'>
-                  <use xlink:href='#icon-check' />
-                </svg>
-              </div>
-              <img class="layer-icon"
-                src="https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/RooftopHub.png">
-              Access Points
-            </label>
-            <label class='checkbox-container'>
-              <input type='checkbox' id="layer3" checked />
-              <div class='checkbox mr6 checkbox--s-label'>
-                <svg class='icon'>
-                  <use xlink:href='#icon-check' />
-                </svg>
-              </div>
-              <img class="layer-icon"
-                src="https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/icon1.png"> Mesh
-              Nodes
-            </label>
-            <label class='checkbox-container'>
-              <input type='checkbox' id="layer5" />
-              <div class='checkbox mr6 checkbox--s-label'>
-                <svg class='icon'>
-                  <use xlink:href='#icon-check' />
-                </svg>
-              </div>
-              Heatmap
-            </label>
-            <div>
-              <label class='checkbox-container'>
-                <input type='checkbox' id="neighborhood-boundaries" />
-                <div class='checkbox mr6 checkbox--s-label'>
-                  <svg class='icon'>
-                    <use xlink:href='#icon-check' />
-                  </svg>
-                </div>
-                Neighborhoods
-              </label>
-              <label class='checkbox-container ml24'>
-                <input type='checkbox' id="neighborhood-outline-only" />
-                <div class='checkbox mr6 checkbox--s-label'>
-                  <svg class='icon'>
-                    <use xlink:href='#icon-check' />
-                  </svg>
-                </div>
-                Outline
-              </label>
+  <div id="map"></div>
+  <div id="right-sidebar" class="sidebar flex-center right collapsed">
+    <div class="sidebar-content rounded-rect flex-center">
+      <div class="bookmarks">
+        <div style="font-weight: bold">Select layers</div>
+        <div class='relative bg-gray-lighter mx6 my6 w180 round flex flex--column'>
+          <label class='checkbox-container'>
+            <input type='checkbox' id="layer1" checked />
+            <div class='checkbox mr6 checkbox--s-label'>
+              <svg class='icon'>
+                <use xlink:href='#icon-check' />
+              </svg>
             </div>
-            <div>
-              <label class='checkbox-container'>
-                <input type='checkbox' id="income-blocks" />
-                <div class='checkbox mr6 checkbox--s-label'>
-                  <svg class='icon'>
-                    <use xlink:href='#icon-check' />
-                  </svg>
-                </div>
-                Income
-              </label>
-
-              <label class='checkbox-container ml24'>
-                <input type='checkbox' id="show-income-popup" checked />
-                <div class='checkbox mr6 checkbox--s-label'>
-                  <svg class='icon'>
-                    <use xlink:href='#icon-check' />
-                  </svg>
-                </div>
-                Show Popup
-              </label>
+            <img class="layer-icon"
+              src="https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/high_sites.png">
+            High Sites
+          </label>
+          <label class='checkbox-container'>
+            <input type='checkbox' id="layer4" checked />
+            <div class='checkbox mr6 checkbox--s-label'>
+              <svg class='icon'>
+                <use xlink:href='#icon-check' />
+              </svg>
             </div>
-            <div>
-              <label class='checkbox-container'>
-                <input type='checkbox' id="broadband-blocks" />
-                <div class='checkbox mr6 checkbox--s-label'>
-                  <svg class='icon'>
-                    <use xlink:href='#icon-check' />
-                  </svg>
-                </div>
-                Broadband Percentage
-              </label>
-
-              <label class='checkbox-container ml24'>
-                <input type='checkbox' id="show-broadband-popup" checked />
-                <div class='checkbox mr6 checkbox--s-label'>
-                  <svg class='icon'>
-                    <use xlink:href='#icon-check' />
-                  </svg>
-                </div>
-                Show Popup
-              </label>
+            <img class="layer-icon"
+              src="https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/Rooftophubs2.png">
+            Main Router
+          </label>
+          <label class='checkbox-container'>
+            <input type='checkbox' id="layer2" checked />
+            <div class='checkbox mr6 checkbox--s-label'>
+              <svg class='icon'>
+                <use xlink:href='#icon-check' />
+              </svg>
             </div>
+            <img class="layer-icon"
+              src="https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/RooftopHub.png">
+            Access Points
+          </label>
+          <label class='checkbox-container'>
+            <input type='checkbox' id="layer3" checked />
+            <div class='checkbox mr6 checkbox--s-label'>
+              <svg class='icon'>
+                <use xlink:href='#icon-check' />
+              </svg>
+            </div>
+            <img class="layer-icon"
+              src="https://raw.githubusercontent.com/phillycommunitywireless/pcwnetworkmap/main/icons/icon1.png"> Mesh
+            Nodes
+          </label>
+          <label class='checkbox-container'>
+            <input type='checkbox' id="layer5" />
+            <div class='checkbox mr6 checkbox--s-label'>
+              <svg class='icon'>
+                <use xlink:href='#icon-check' />
+              </svg>
+            </div>
+            Heatmap
+          </label>
+          <div>
+            <label class='checkbox-container'>
+              <input type='checkbox' id="neighborhood-boundaries" />
+              <div class='checkbox mr6 checkbox--s-label'>
+                <svg class='icon'>
+                  <use xlink:href='#icon-check' />
+                </svg>
+              </div>
+              Neighborhoods
+            </label>
+            <label class='checkbox-container ml24'>
+              <input type='checkbox' id="neighborhood-outline-only" />
+              <div class='checkbox mr6 checkbox--s-label'>
+                <svg class='icon'>
+                  <use xlink:href='#icon-check' />
+                </svg>
+              </div>
+              Outline
+            </label>
           </div>
-          <div style="font-weight: bold">Navigate to</div>
-          <div class="inline-flex flex--column">
-            <button class="btn btn--gray btn--pill-vt" id="norris_square">Norris Sq. Park</button>
-            <button class="btn btn--gray btn--pill-vc" id="fairhill_square">Fairhill Sq. Park</button>
-            <button class="btn btn--gray btn--pill-vb" id="mcpherson_square">McPherson Sq. Park</button>
-          </div>
-          <div style="font-weight: bold">Show Connections</div>
-          <label class="switch-container">
-            <input type="checkbox" id="toggleNetworkLinks" disabled />
-            <div class="switch"></div>
-            <div class="ms-small">High Sites to Routers</div>
-          </label>
-          <label class="switch-container">
-            <input type="checkbox" id="toggleNetworkLinks2" disabled />
-            <div class="switch"></div>
-            <div class="ms-small">Routers to Wired APs</div>
-          </label>
-          <label class="switch-container">
-            <input type="checkbox" id="toggleNetworkLinks3" disabled />
-            <div class="switch"></div>
-            <div class="ms-small">Wired APs to Mesh Nodes</div>
-          </label>
-        </div>
-        <div class="sidebar-toggle rounded-rect right">
-          &larr;
-        </div>
+          <div>
+            <label class='checkbox-container'>
+              <input type='checkbox' id="income-blocks" />
+              <div class='checkbox mr6 checkbox--s-label'>
+                <svg class='icon'>
+                  <use xlink:href='#icon-check' />
+                </svg>
+              </div>
+              Income
+            </label>
 
+            <label class='checkbox-container ml24'>
+              <input type='checkbox' id="show-income-popup" checked />
+              <div class='checkbox mr6 checkbox--s-label'>
+                <svg class='icon'>
+                  <use xlink:href='#icon-check' />
+                </svg>
+              </div>
+              Show Popup
+            </label>
+          </div>
+          <div>
+            <label class='checkbox-container'>
+              <input type='checkbox' id="broadband-blocks" />
+              <div class='checkbox mr6 checkbox--s-label'>
+                <svg class='icon'>
+                  <use xlink:href='#icon-check' />
+                </svg>
+              </div>
+              Broadband Percentage
+            </label>
+
+            <label class='checkbox-container ml24'>
+              <input type='checkbox' id="show-broadband-popup" checked />
+              <div class='checkbox mr6 checkbox--s-label'>
+                <svg class='icon'>
+                  <use xlink:href='#icon-check' />
+                </svg>
+              </div>
+              Show Popup
+            </label>
+          </div>
+        </div>
+        <div style="font-weight: bold">Navigate to</div>
+        <div class="inline-flex flex--column">
+          <button class="btn btn--gray btn--pill-vt" id="norris_square">Norris Sq. Park</button>
+          <button class="btn btn--gray btn--pill-vc" id="fairhill_square">Fairhill Sq. Park</button>
+          <button class="btn btn--gray btn--pill-vb" id="mcpherson_square">McPherson Sq. Park</button>
+        </div>
+        <div style="font-weight: bold">Show Connections</div>
+        <label class="switch-container">
+          <input type="checkbox" id="toggleNetworkLinks" disabled />
+          <div class="switch"></div>
+          <div class="ms-small">High Sites to Routers</div>
+        </label>
+        <label class="switch-container">
+          <input type="checkbox" id="toggleNetworkLinks2" disabled />
+          <div class="switch"></div>
+          <div class="ms-small">Routers to Wired APs</div>
+        </label>
+        <label class="switch-container">
+          <input type="checkbox" id="toggleNetworkLinks3" disabled />
+          <div class="switch"></div>
+          <div class="ms-small">Wired APs to Mesh Nodes</div>
+        </label>
       </div>
+      <div class="sidebar-toggle rounded-rect right">
+        &larr;
+      </div>
+
     </div>
   </div>
 


### PR DESCRIPTION
per warning message from the mapbox engine on window load - see below.

As the sidebar is positioned `absolute` and the map is expanded to the entirety of the container, there is no concern about positioning issues. There is also no css targeting the nested `#map .right-sidebar ...`

![image](https://github.com/user-attachments/assets/3c87fb6d-7df8-439f-88a7-013ec0856de3)
