### PR TITLE
add documentation on pre-zooming the map

### DIFF
--- a/css/help-dialog.css
+++ b/css/help-dialog.css
@@ -38,6 +38,7 @@
 	max-height: 90%;
 	background-color: white;
 	z-index: 1;
+	word-wrap: break-word;
 }
 
 #help-dialog-header {
@@ -48,7 +49,7 @@
 	display: flex;
 	justify-content: space-between;
 	background-color: white;
-	padding: 12px 18px;
+	padding: 12px 18px 0px 18px;
 }
 
 #help-dialog-body {
@@ -60,4 +61,30 @@
 	#help-dialog-container {
 		width: 100%;
 	}	
+}
+
+/* 
+	Styling links on the help dialog box - default 
+	just inerhits default text color. 
+*/
+.help-dialog-link {
+	color: blue;
+	text-decoration: underline;
+}
+
+/* 
+	Add padding to help dialog text for readability 
+*/
+.txt-xl {
+	padding: 1rem 0rem 0rem;
+}
+
+/* 
+	Ensure the help dialog box doesn't stretch 
+	too far horizontally on extra large screens
+*/
+@media screen and (min-width: 1600px) {
+	#help-dialog-container {
+		max-width: 50%;
+	}
 }

--- a/js/controls/help-dialog.control.js
+++ b/js/controls/help-dialog.control.js
@@ -33,6 +33,20 @@ const popupHTML = `
 		Your view will 'fly to' the designated location and shift to a 3D rendering.</p>
 		<p>To reset this view to the normal 2D orientation, click the compass button
 		in the lower-right of the map, below the zoom icons ( +, - )</p>
+		
+		<h2 class="txt-xl">Pre-centering the map via link</h2>
+		<p>
+			It may be useful in some instances to have the map pre-zoomed on a given location of interest
+			instead of having to fly there manually. To do so, find the latitude, longitude, and desired zoom 
+			level using <a class="help-dialog-link" href="https://labs.mapbox.com/location-helper">MapBox's geolocation helper</a>, and then add 
+			the values to the URL like so: 
+		</p>
+		<a class="help-dialog-link" href="/?latitude=39.95239&longitude=-75.16364&zoom=16">
+			https://phillycommunitywireless.github.io/pcwnetworkmap/?latitude=39.95239&longitude=-75.16364&zoom=16
+		</a>
+		<p>
+			For example, the above URL is centered/zoomed on City Hall.
+		</p>
 	</div>
 </div>
 `;


### PR DESCRIPTION
On the help dialog box - added an example URL as well: 

![image](https://github.com/user-attachments/assets/eb776652-29fd-4242-b4f7-f3ca83b938cb)

Also added some ui tweaks to prevent the help dialog box from stretching too far on XL screens! 