### PR TITLE
more accurate heatmap

### DIFF
--- a/js/layers/load-heatmap.js
+++ b/js/layers/load-heatmap.js
@@ -13,6 +13,43 @@ export default (network_points_data) => {
 		},
 	});
 
+	function ConvertFeetToPixels(zoomLevel, distanceInFeet) {
+		let pixelLegnth;
+		switch (zoomLevel) {
+			case 12:
+				pixelLegnth = distanceInFeet * 0.01; // @1px for 100ft
+				break;
+			case 13:
+				pixelLegnth = distanceInFeet * 0.04 // @4px for 100ft
+				break;
+			case 14:
+				pixelLegnth = distanceInFeet * 0.07; // @7px for 100ft
+				break;
+			case 15:
+				pixelLegnth = distanceInFeet * 0.24; // @24px for 100ft
+				break;
+			case 16:
+				pixelLegnth = distanceInFeet * 0.4; // @40px for 100ft
+				break;
+			case 17:
+				pixelLegnth = distanceInFeet * 1.4; // @140px for 100ft
+				break;
+			case 18:
+				pixelLegnth = distanceInFeet * 2.4;// @240px for 100ft
+				break;
+			case 19:
+				pixelLegnth = distanceInFeet * 8.4;// @840px for 100ft
+				break;
+			case 20:
+				pixelLegnth = distanceInFeet * 14.4;// @1440px for 100ft
+				break;
+			default:
+				pixelLegnth = 1;
+
+		}
+		return Math.round(pixelLegnth);
+	}
+
 	const heatmapLayer = {
 		id: 'heatmap-layer',
 		type: 'heatmap',
@@ -20,7 +57,7 @@ export default (network_points_data) => {
 		minzoom: 12,
 		maxzoom: 20,
 		paint: {
-			'heatmap-weight': 5,
+			'heatmap-weight': 1,
 			'heatmap-intensity': 1,
 			'heatmap-color': [
 				'interpolate',
@@ -37,17 +74,17 @@ export default (network_points_data) => {
 				0.8,
 				'rgba(0, 255, 0, 1)',
 			],
-			'heatmap-radius': {
-				stops: [
-					[9, 2],
-					[11, 10],
-					[13, 20],
-					[15, 100],
-					[17, 200],
-					[19, 500],
-					[23, 1000],
-				],
-			},
+			'heatmap-radius': [
+				'interpolate',
+				['linear'],
+				['zoom'],
+				// 'ap_type' instead of 'type' to go by specific router used instead of general Mesh or Access Point check
+				12, ['match', ['get', 'type'], 'RH', ConvertFeetToPixels(12, 500), 'MN', ConvertFeetToPixels(12, 500), 'LB', 1, 1], // map zoomed out
+				14, ['match', ['get', 'type'], 'RH', ConvertFeetToPixels(14, 500), 'MN', ConvertFeetToPixels(14, 500), 'LB', 1, 1],
+				16, ['match', ['get', 'type'], 'RH', ConvertFeetToPixels(16, 500), 'MN', ConvertFeetToPixels(16, 500), 'LB', 1, 1],
+				18, ['match', ['get', 'type'], 'RH', ConvertFeetToPixels(18, 500), 'MN', ConvertFeetToPixels(18, 500), 'LB', 1, 1],
+				20, ['match', ['get', 'type'], 'RH', ConvertFeetToPixels(20, 500), 'MN', ConvertFeetToPixels(20, 500), 'LB', 1, 1], // map zoomed in
+			],
 			'heatmap-opacity': {
 				default: 1,
 				stops: [


### PR DESCRIPTION
Changed the 'heatmap-radius' parameter so it can account for whether one of the points it's using is a router, and access point, or a mesh point. As far as I can tell the access point('RH') devices and mesh point ('MN') devices have similar ranges so that's reflected. Both have been adjusted to reflect a 500 foot range. Routers('LB') no longer add to the heatmap impression.

Adjusted the 'heatmap-weight' to 1 to more accurately reflect signal falloff.

Added a function that takes how far the map is zoomed in and a given distance in feet to convert the distance in feet to an appropriate diameter in pixels.