### PR TITLE
Heatmap improvement

### DIFF
--- a/js/layers/load-heatmap.js
+++ b/js/layers/load-heatmap.js
@@ -14,40 +14,40 @@ export default (network_points_data) => {
 	});
 
 	function ConvertFeetToPixels(zoomLevel, distanceInFeet) {
-		let pixelLegnth;
+		let pixelLength;
 		switch (zoomLevel) {
 			case 12:
-				pixelLegnth = distanceInFeet * 0.03; // @3px for 100ft
+				pixelLength = distanceInFeet * 0.03; // @3px for 100ft
 				break;
 			case 13:
-				pixelLegnth = distanceInFeet * 0.07 // @7px for 100ft
+				pixelLength = distanceInFeet * 0.07 // @7px for 100ft
 				break;
 			case 14:
-				pixelLegnth = distanceInFeet * 0.11; // 11px for 100ft
+				pixelLength = distanceInFeet * 0.11; // 11px for 100ft
 				break;
 			case 15:
-				pixelLegnth = distanceInFeet * 0.24; // @24px for 100ft
+				pixelLength = distanceInFeet * 0.24; // @24px for 100ft
 				break;
 			case 16:
-				pixelLegnth = distanceInFeet * 0.4; // @40px for 100ft
+				pixelLength = distanceInFeet * 0.4; // @40px for 100ft
 				break;
 			case 17:
-				pixelLegnth = distanceInFeet * 0.9; // @90px for 100ft
+				pixelLength = distanceInFeet * 0.9; // @90px for 100ft
 				break;
 			case 18:
-				pixelLegnth = distanceInFeet * 1.4;// @140px for 100ft
+				pixelLength = distanceInFeet * 1.4;// @140px for 100ft
 				break;
 			case 19:
-				pixelLegnth = distanceInFeet * 3.1;// @310px for 100ft
+				pixelLength = distanceInFeet * 3.1;// @310px for 100ft
 				break;
 			case 20:
-				pixelLegnth = distanceInFeet * 4.8;// @480px for 100ft
+				pixelLength = distanceInFeet * 4.8;// @480px for 100ft
 				break;
 			default:
-				pixelLegnth = 1;
+				pixelLength = 1;
 
 		}
-		return Math.round(pixelLegnth);
+		return Math.round(pixelLength);
 	}
 
 	const heatmapLayer = {


### PR DESCRIPTION
Migrate contents of this PR from @eawaters [fork](https://github.com/eawaters/pcwnetworkmap) for deploy preview

> Changed the 'heatmap-radius' parameter so it can account for whether one of the points it's using is a router, and access point, or a mesh point. As far as I can tell the access point('RH') devices and mesh point ('MN') devices have similar ranges so that's reflected. Both have been adjusted to reflect a 500 foot range. Routers('LB') no longer add to the heatmap impression.
>
> Adjusted the 'heatmap-weight' to 1 to more accurately reflect signal falloff.
>
> Added a function that takes how far the map is zoomed in and a given distance in feet to convert the distance in feet to an appropriate diameter in pixels.

https://github.com/phillycommunitywireless/pcwnetworkmap/pull/75 - original PR

addresses https://github.com/phillycommunitywireless/pcwnetworkmap/issues/16 
